### PR TITLE
show correct WiFi status

### DIFF
--- a/main/web_server.c
+++ b/main/web_server.c
@@ -691,7 +691,7 @@ static esp_err_t status_get_handler(httpd_req_t *req) {
     }
 
     cJSON *sta = cJSON_AddObjectToObject(wifi, "sta");
-    cJSON_AddBoolToObject(sta, "active", ap_status.active);
+    cJSON_AddBoolToObject(sta, "active", sta_status.active);
     if (sta_status.active) {
         cJSON_AddBoolToObject(sta, "connected", sta_status.connected);
         if (sta_status.connected) {


### PR DESCRIPTION
This fixes the WiFi display showing "Not Active" while its in use.

Looks like this now:
![grafik](https://github.com/incarvr6/esp32-ntrip-DUO/assets/1591573/870a30ac-77c2-49a2-8e31-817556058f97)
